### PR TITLE
Add WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,8 @@ ENV ASPNETCORE_URLS=http://+:80 \
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
+WORKDIR /projects
+
 ADD etc/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Adds WORKDIR into the Dockerfile to fix the problem with running netcoredbg.